### PR TITLE
Ignore pasted-in input in main menu

### DIFF
--- a/yt-dl/Menu.cs
+++ b/yt-dl/Menu.cs
@@ -6,6 +6,26 @@ namespace yt_dl
 {
     class Menu
     {
+        public char ReadSingleKey()
+        {
+            while (true) {
+                char c = ReadKey().KeyChar;
+                if (KeyAvailable) // Input was pasted in
+                {
+                    while (KeyAvailable)
+                    {
+                        Write("\b");
+                        ReadKey();
+                    }
+                    Write("\b \b");
+                }
+                else // There are no more chars queued, so user must
+                {    // have typed manually
+                    return c;
+                }
+            }
+        }
+        
         public void Start()
         {
             Call app = new Call();
@@ -55,7 +75,8 @@ namespace yt_dl
                           "8. Show Download path\n" +
                           "9. Change Download path");
                 Write("#");
-                choice = ReadKey().KeyChar;
+                choice = ReadSingleKey();
+                
                 if (choice == '1') //Audio
                 {
                     app.Audio();


### PR DESCRIPTION
Users reported that they often accidentally paste in URLs into the main menu.

The main menu previously processed each char of the input separately. This PR detects if the input was pasted in and discards it in that case.