### PR TITLE
Switch from PyQt5 to PySide6

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -2,16 +2,13 @@ import sys, os
 import glob, json
 import subprocess
 import tempfile
-from PyQt5 import QtWidgets, uic
-from PyQt5.QtWidgets import QFileDialog, QMessageBox, QApplication
+from PySide2 import QtCore, QtWidgets, QtUiTools
+from PySide2.QtWidgets import QFileDialog, QMessageBox, QApplication
 
 from call import year, lstupdt, spath, settings
 
 class MainWindow(QtWidgets.QMainWindow):    
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        uic.loadUi("gui.ui", self)
-
+    def init(self):
         def MessagePopup(title, icon, text, callf=None):
             msg = QMessageBox()
             msg.setWindowTitle(title)
@@ -679,6 +676,9 @@ class MainWindow(QtWidgets.QMainWindow):
                               +f"You can read the changelog: <a href=\"https://github.com/KoleckOLP/yt-dl/blob/master/whatsnew.md\">here</a></pre></p>")  
 
 app = QtWidgets.QApplication(sys.argv)
-window = MainWindow()
+loader = QtUiTools.QUiLoader() # load the gui file into a new instance of the "cls" Python class
+loader.registerCustomWidget(MainWindow)
+window = loader.load("gui.ui")
+window.init()
 window.show()
 app.exec_()

--- a/gui.ui
+++ b/gui.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>ytdl</class>
- <widget class="QMainWindow" name="ytdl">
+ <widget class="MainWindow" name="ytdl">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorama
 py-getch
-pyqt5
+pyside6
 wheel
 youtube-dl


### PR DESCRIPTION
PySide's .ui loading mechanisms work differently than PyQt's, so the .ui loading code was moved towards the bottom of the file.

Also, in the GUI file `gui.ui`, the main widget name was changed from "QMainWindow" to "MainWindow" to get PySide to load the file as the proper type.